### PR TITLE
Add instructions for nginx and php dependencies in 01_Installation.md

### DIFF
--- a/en/docs/users/01_Installation.md
+++ b/en/docs/users/01_Installation.md
@@ -74,7 +74,7 @@ server {
 
   # php files handling
   # this regex is mandatory because of the API
-  location ~ ^/.*\.php(/.*)?$ {
+  location ~ ^.+?\.php(/.*)?$ {
     fastcgi_pass unix:/var/run/php5-fpm.sock;
     fastcgi_split_path_info ^(.+\.php)(/.*)$;
     # By default, the variable PATH_INFO is not set under PHP-FPM

--- a/en/docs/users/01_Installation.md
+++ b/en/docs/users/01_Installation.md
@@ -8,7 +8,7 @@ You need to verify that your server can run FreshRSS before installing it. If yo
 | ----------- | ---------------- | ----------------------------- |
 | Web server  | **Apache 2**     | Nginx                         |
 | PHP         | **PHP 5.3.7+**   | PHP 5.2+                      |
-| PHP modules | Required: libxml, cURL, PDO_MySQL, PCRE, ctype and GMP \\ Recommanded: JSON, Zlib, mbstring, iconv, ZipArchive | |
+| PHP modules | Required: libxml, cURL, PDO_MySQL, PCRE and ctype. \\ Required (32-bit only): GMP \\Recommanded: JSON, Zlib, mbstring, iconv, ZipArchive | |
 | Database    | **MySQL 5.0.3+** | SQLite 3.7.4+                 |
 | Browser     | **Firefox**      | Chrome, Opera, Safari or IE9+ |
 
@@ -74,7 +74,7 @@ server {
 
   # php files handling
   # this regex is mandatory because of the API
-  location ~ ^/(.*)\.php(.*)$ {
+  location ~ ^/.*\.php(/.*)?$ {
     fastcgi_pass unix:/var/run/php5-fpm.sock;
     fastcgi_split_path_info ^(.+\.php)(/.*)$;
     # By default, the variable PATH_INFO is not set under PHP-FPM

--- a/en/docs/users/01_Installation.md
+++ b/en/docs/users/01_Installation.md
@@ -8,7 +8,7 @@ You need to verify that your server can run FreshRSS before installing it. If yo
 | ----------- | ---------------- | ----------------------------- |
 | Web server  | **Apache 2**     | Nginx                         |
 | PHP         | **PHP 5.3.7+**   | PHP 5.2+                      |
-| PHP modules | Required: libxml, cURL, PDO_MySQL, PCRE and ctype \\ Recommanded: JSON, Zlib, mbstring, iconv, ZipArchive | |
+| PHP modules | Required: libxml, cURL, PDO_MySQL, PCRE, ctype and GMP \\ Recommanded: JSON, Zlib, mbstring, iconv, ZipArchive | |
 | Database    | **MySQL 5.0.3+** | SQLite 3.7.4+                 |
 | Browser     | **Firefox**      | Chrome, Opera, Safari or IE9+ |
 

--- a/en/docs/users/01_Installation.md
+++ b/en/docs/users/01_Installation.md
@@ -48,7 +48,49 @@ As its name suggests, it is the working release for developers. **This release i
 
 # Nginx installation
 
-**TODO**
+This is an example nginx configuration file. It covers http, https and php-fpm configuration.
+
+```
+server {
+  listen 80; # http on port 80
+  listen 443 ssl; # https on port 443
+
+  # https configuration 
+  ssl on;
+  ssl_certificate      /etc/nginx/server.crt;
+  ssl_certificate_key  /etc/nginx/server.key;
+
+  # your server's url(s)
+  server_name example.com rss.example.com;
+
+  # the folder p of your FreshRSS installation
+  root /srv/FreshRSS/p/;
+
+  index index.php index.html index.htm;
+
+  # nginx log files
+  access_log /var/log/nginx/rss.access.log;
+  error_log /var/log/nginx/rss.error.log;
+
+  # php files handling
+  # this regex is mandatory because of the API
+  location ~ ^/(.*)\.php(.*)$ {
+    fastcgi_pass unix:/var/run/php5-fpm.sock;
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    # By default, the variable PATH_INFO is not set under PHP-FPM
+    # But FreshRSS API greader.php need it. If you have a "Bad Request" error, double check this var !
+    fastcgi_param PATH_INFO $fastcgi_path_info;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  }
+  
+  location / {
+    try_files $uri $uri/ index.php;
+  }
+}
+```
+
+
 
 # Security
 

--- a/en/docs/users/01_Installation.md
+++ b/en/docs/users/01_Installation.md
@@ -50,6 +50,8 @@ As its name suggests, it is the working release for developers. **This release i
 
 This is an example nginx configuration file. It covers http, https and php-fpm configuration.
 
+_You can find simpler config file but they may be incompatible with FreshRSS API._
+
 ```
 server {
   listen 80; # http on port 80

--- a/fr/docs/users/01_Installation.md
+++ b/fr/docs/users/01_Installation.md
@@ -51,7 +51,7 @@ Cette partie n'a pas encore été écrite. Néanmoins, comme il s'agit d'une bê
 
 Voici un fichier de configuration pour nginx. Il couvre la configuration pour http, https et php.
 
-_Vous pourrez trouver d'autres fichiers sur Google plus simples mais ne vous permettront peut-être pas d'utiliser l'API FreshRSS._
+_Vous pourrez trouver d'autres fichiers de configuration plus simples mais ces derniers ne seront peut-être pas compatibles avec l'API FreshRSS._
 
 ```
 server {

--- a/fr/docs/users/01_Installation.md
+++ b/fr/docs/users/01_Installation.md
@@ -8,7 +8,7 @@ Il est toutefois de votre responsabilité de vérifier que votre hébergement pe
  | --------         | -----------                                                                                                    | ---------------------          |
  | Serveur web      | **Apache 2**                                                                                                   | Nginx                          |
  | PHP              | **PHP 5.3.7+**                                                                                                 | PHP 5.2+                       |
- | Modules PHP      | Requis : libxml, cURL, PDO_MySQL, PCRE, ctype et GMP \\ Recommandé : JSON, Zlib, mbstring et iconv, ZipArchive |                                |
+ | Modules PHP      | Requis : libxml, cURL, PDO_MySQL, PCRE et ctype \\ Requis (32 bits seulement) : GMP \\ Recommandé : JSON, Zlib, mbstring et iconv, ZipArchive |                                |
  | Base de données  | **MySQL 5.0.3+**                                                                                               | SQLite 3.7.4+                  |
  | Navigateur       | **Firefox**                                                                                                    | Chrome, Opera, Safari or IE 9+ |
 
@@ -77,7 +77,7 @@ server {
 
   # gestion des fichiers php
   # il est nécessaire d'utiliser cette expression régulière pour le bon fonctionnement de l'API 
-  location ~ ^/(.*)\.php(.*)$ {
+  location ~ ^/.*\.php(/.*)?$ {
     fastcgi_pass unix:/var/run/php5-fpm.sock;
     fastcgi_split_path_info ^(.+\.php)(/.*)$;
     # Par défaut la variable PATH_INFO n'est pas définie sous PHP-FPM

--- a/fr/docs/users/01_Installation.md
+++ b/fr/docs/users/01_Installation.md
@@ -77,7 +77,7 @@ server {
 
   # gestion des fichiers php
   # il est nécessaire d'utiliser cette expression régulière pour le bon fonctionnement de l'API 
-  location ~ ^/.*\.php(/.*)?$ {
+  location ~ ^.+?\.php(/.*)?$ {
     fastcgi_pass unix:/var/run/php5-fpm.sock;
     fastcgi_split_path_info ^(.+\.php)(/.*)$;
     # Par défaut la variable PATH_INFO n'est pas définie sous PHP-FPM

--- a/fr/docs/users/01_Installation.md
+++ b/fr/docs/users/01_Installation.md
@@ -8,7 +8,7 @@ Il est toutefois de votre responsabilité de vérifier que votre hébergement pe
  | --------         | -----------                                                                                                | ---------------------          | 
  | Serveur web      | **Apache 2**                                                                                               | Nginx                          | 
  | PHP              | **PHP 5.3.7+**                                                                                             | PHP 5.2+                       | 
- | Modules PHP      | Requis : libxml, cURL, PDO_MySQL, PCRE et ctype \\ Recommandé : JSON, Zlib, mbstring et iconv, ZipArchive |                                | 
+ | Modules PHP      | Requis : libxml, cURL, PDO_MySQL, PCRE, ctype et GMP \\ Recommandé : JSON, Zlib, mbstring et iconv, ZipArchive |                                | 
  | Base de données | **MySQL 5.0.3+**                                                                                           | SQLite 3.7.4+                  | 
  | Navigateur       | **Firefox**                                                                                                | Chrome, Opera, Safari or IE 9+ | 
 

--- a/fr/docs/users/01_Installation.md
+++ b/fr/docs/users/01_Installation.md
@@ -4,13 +4,13 @@ FreshRSS est un logiciel développé en PHP reposant sur le modèle client - ser
 
 Il est toutefois de votre responsabilité de vérifier que votre hébergement permettra de faire tourner FreshRSS avant de nous taper dessus. Dans le cas où les informations listées ci-dessous ne seraient pas à jour, vous pourrez.
 
- | Logiciel         | Recommandé                                                                                                | Fonctionne aussi avec          | 
- | --------         | -----------                                                                                                | ---------------------          | 
- | Serveur web      | **Apache 2**                                                                                               | Nginx                          | 
- | PHP              | **PHP 5.3.7+**                                                                                             | PHP 5.2+                       | 
- | Modules PHP      | Requis : libxml, cURL, PDO_MySQL, PCRE, ctype et GMP \\ Recommandé : JSON, Zlib, mbstring et iconv, ZipArchive |                                | 
- | Base de données | **MySQL 5.0.3+**                                                                                           | SQLite 3.7.4+                  | 
- | Navigateur       | **Firefox**                                                                                                | Chrome, Opera, Safari or IE 9+ | 
+ | Logiciel         | Recommandé                                                                                                     | Fonctionne aussi avec          |
+ | --------         | -----------                                                                                                    | ---------------------          |
+ | Serveur web      | **Apache 2**                                                                                                   | Nginx                          |
+ | PHP              | **PHP 5.3.7+**                                                                                                 | PHP 5.2+                       |
+ | Modules PHP      | Requis : libxml, cURL, PDO_MySQL, PCRE, ctype et GMP \\ Recommandé : JSON, Zlib, mbstring et iconv, ZipArchive |                                |
+ | Base de données  | **MySQL 5.0.3+**                                                                                               | SQLite 3.7.4+                  |
+ | Navigateur       | **Firefox**                                                                                                    | Chrome, Opera, Safari or IE 9+ |
 
 ## Note importante
 
@@ -49,9 +49,51 @@ Cette partie n'a pas encore été écrite. Néanmoins, comme il s'agit d'une bê
 
 # Installation sur Nginx
 
-**TODO**
+Voici un fichier de configuration pour nginx. Il couvre la configuration pour http, https et php.
 
-Cette partie n'a pas encore été écrite. Vous pouvez néanmoins suivre [un article dédié](http://www.pihomeserver.fr/2013/05/08/raspberry-pi-home-server-installer-un-agregateur-de-flux-rss-pour-remplacer-google-reader/).
+_Vous pourrez trouver d'autres fichiers sur Google plus simples mais ne vous permettront peut-être pas d'utiliser l'API FreshRSS._
+
+```
+server {
+  listen 80; # http sur le port 80
+  listen 443 ssl; # https sur le port 443
+
+  # configuration https 
+  ssl on;
+  ssl_certificate      /etc/nginx/server.crt;
+  ssl_certificate_key  /etc/nginx/server.key;
+
+  # l'url ou les urls de votre serveur
+  server_name example.com rss.example.com;
+
+  # le répertoire où se trouve le dossier p de FreshRSS
+  root /srv/FreshRSS/p/;
+
+  index index.php index.html index.htm;
+
+  # les fichiers de log nginx
+  access_log /var/log/nginx/rss.access.log;
+  error_log /var/log/nginx/rss.error.log;
+
+  # gestion des fichiers php
+  # il est nécessaire d'utiliser cette expression régulière pour le bon fonctionnement de l'API 
+  location ~ ^/(.*)\.php(.*)$ {
+    fastcgi_pass unix:/var/run/php5-fpm.sock;
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    # Par défaut la variable PATH_INFO n'est pas définie sous PHP-FPM
+    # or l'API FreshRSS greader.php en a besoin. Si vous avez un "Bad Request", vérifiez bien cette dernière !
+    fastcgi_param PATH_INFO $fastcgi_path_info;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  }
+  
+  location / {
+    try_files $uri $uri/ index.php;
+  }
+}
+```
+
+Pour un tutoriel pas à pas, vous pouvez suivre [cet article dédié](http://www.pihomeserver.fr/2013/05/08/raspberry-pi-home-server-installer-un-agregateur-de-flux-rss-pour-remplacer-google-reader/).
 
 # Conseils de sécurité
 


### PR DESCRIPTION
I've added my personal nginx configuration to the doc. It covers http and https. I use php-fpm (could be interesting to test FreshRSS with hhvm :grinning:  ). PHP part is a bit complex because of greader.php routing.

---

GMP is used  in greader.php API

```
PHP message: PHP Fatal error:  Call to undefined function gmp_strval() in /srv/FreshRSS/p/api/greader.php on line 30" while reading response header from upstream
```